### PR TITLE
Update Rack for security patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (2.1.1)
+    rack (2.2.3)
     rack-protection (2.0.8.1)
       rack
     rack-test (1.1.0)


### PR DESCRIPTION
```
rack (< 2.1.4)
  Fixed in: 2.1.4
  Details: Percent-encoded cookies can be used to overwrite existing prefixed cookie names
```